### PR TITLE
making sure that a previous timer is properly cleared

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,13 @@ module.exports = (pattern, {
 
       // prevent events queued after the original timeout fired
       // from scheduling another event
-      pending[abspath].timer = -1;
+      if (ref.timer) {
+        clearTimeout(ref.timer);
+        ref.timer = -1;
+      }
+      if (pending[abspath]) {
+        pending[abspath].timer = -1;
+      }
 
       // always check that this file exists on a change event due to a bug
       // in node 12 that fires a delete as a change instead of rename


### PR DESCRIPTION
resetting both the ref timer and the pending stored timer (in case they are different), only if a pending stored timer exists

This addresses #20 